### PR TITLE
Import explorers and bugfix in crawler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -215,6 +215,12 @@
             <version>2.0.4</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-csv</artifactId>
+            <version>2.4.0</version>
+        </dependency>
+
         <!-- Gephi dependencies -->
 
         <dependency>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration debug="false"> 
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender"> 
+    <!-- encoders are  by default assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="${root-level:-INFO}">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/src/main/scala/io/ssc/angles/pipeline/batch/SimilarDocuments.scala
+++ b/src/main/scala/io/ssc/angles/pipeline/batch/SimilarDocuments.scala
@@ -49,11 +49,13 @@ object SimilarDocuments extends App {
     val searcher = new IndexSearcher(reader)
 
     var communityFilename: String = null
-    if (params.length > 1) {
+    if (params.length >= 1) {
       communityFilename = params(0)
     } else {
       communityFilename = "communities-manual.tsv"
     }
+
+    println("Reading communities from " + communityFilename + " ...")
 
     //  val fields = MultiFields.getFields(reader)
 

--- a/src/main/scala/io/ssc/angles/pipeline/data/Storage.scala
+++ b/src/main/scala/io/ssc/angles/pipeline/data/Storage.scala
@@ -266,6 +266,12 @@ object Storage {
       insert.into(Explorer).values(user.getId, user.getScreenName, user.getName, user.getDescription)
     }.update.apply()
   }
+
+  def saveExplorer(id: String, screenName : String) = {
+    withSQL {
+      insert.into(Explorer).values(id, screenName, screenName, null)
+    }.update.apply()
+  }
   
   def allTweetURIPairs() = {
     sql"SELECT t.explorer_id, w.real_uri FROM tweets t JOIN crawled_websites w ON t.id = w.tweet_id;" map {

--- a/src/main/scala/io/ssc/angles/pipeline/explorers/CalculateClusters.scala
+++ b/src/main/scala/io/ssc/angles/pipeline/explorers/CalculateClusters.scala
@@ -33,9 +33,14 @@ object CalculateClusters extends App {
       return
     }
 
+    var i = -1
+
+    // Put each explorer without cluster in a separate cluster
     explorers.foreach{s =>
-        if (!clusterMap.containsValue(s))
+        if (!clusterMap.containsValue(s)) {
           clusterMap.put(-1, s)
+          i -= 1
+        }
     }
   }
 

--- a/src/main/scala/io/ssc/angles/pipeline/explorers/ImportExplorers.scala
+++ b/src/main/scala/io/ssc/angles/pipeline/explorers/ImportExplorers.scala
@@ -1,0 +1,39 @@
+package io.ssc.angles.pipeline.explorers
+
+import java.sql.SQLException
+
+import io.ssc.angles.pipeline.data.Storage
+import org.slf4j.LoggerFactory
+
+/**
+ * Application for importing explorers to the angles database. Note that this will be
+ */
+object ImportExplorers extends App {
+
+  override def main(args: Array[String]) {
+
+    val logger = LoggerFactory.getLogger(getClass)
+
+    val allExplorerIds = Storage.allExplorers().map(e => e.id).toSet
+
+    if (args.length != 1) {
+      logger.error("Filename missing")
+    } else {
+      val filename = args(0)
+      val tuples = CSVReader.readTuplesFromCSV(filename).map(t => (t._1, t._2)).foreach { x =>
+        if (!allExplorerIds.contains(x._1.toLong)) {
+          try {
+            Storage.saveExplorer(x._1, x._2)
+            logger.info("Added explorer {}", x)
+          } catch {
+            case e: SQLException => logger.warn("Adding explorer {} failed: {}", x.toString().asInstanceOf[Any], e.getMessage.asInstanceOf[Any])
+          }
+        } else {
+          logger.info("Explorer {} already in database", x)
+        }
+      }
+      logger.info("Done.")
+    }
+  }
+
+}


### PR DESCRIPTION
Changes:
- New app for importing the explorers from pairs.csv into the angles database (io.ssc.angles.pipeline.explorers.ImportExplorers)
- Skip TwitterException "(401:Authentication credentials (https://dev.twitter.com/pages/auth) were missing or incorrect.") in FetchTimelines
  -> Usually caused by missing authorization for accessing a timeline
